### PR TITLE
Upgrade to C++17, fixing macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package (OpenSSL REQUIRED)
 set (acme_lw_client_VERSION_MAJOR 0)
 set (acme_lw_client_VERSION_MINOR 2)
 set (acme_lw_client_VERSION_PATCH 1)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 OPTION(STAGING "Run against the Let's Encrypt staging environment" OFF)
 if (STAGING)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,6 +5,6 @@ add_library(acme_lw ${source})
 install (TARGETS acme_lw DESTINATION lib)
 install (FILES acme-exception.h acme-lw.h DESTINATION include)
 
-target_include_directories(acme_lw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../internal )
+target_include_directories(acme_lw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../internal ${OPENSSL_INCLUDE_DIR})
 
 target_link_libraries(acme_lw PRIVATE crypto)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,4 +7,4 @@ install (FILES acme-exception.h acme-lw.h DESTINATION include)
 
 target_include_directories(acme_lw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../internal ${OPENSSL_INCLUDE_DIR})
 
-target_link_libraries(acme_lw PRIVATE crypto)
+target_link_libraries(acme_lw PRIVATE ${OPENSSL_LIBRARIES})

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,10 @@
 file (GLOB_RECURSE source "*.cpp" "*.h")
 
 add_executable(acme_lw_client ${source})
-
+if (APPLE)
+target_link_libraries(acme_lw_client PRIVATE acme_lw curl)
+else()
 target_link_libraries(acme_lw_client PRIVATE acme_lw curl stdc++fs)
+endif()
 
 install (TARGETS acme_lw_client DESTINATION bin)

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3,8 +3,9 @@
 #include <cerrno>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
-#include <experimental/filesystem>
+#include <filesystem>
 
 using namespace std;
 
@@ -128,8 +129,8 @@ void writeFile(const string& fileName, const string& contents)
     }
 
     rawWriteFile(fileName, "");
-    experimental::filesystem::permissions(fileName, experimental::filesystem::perms::owner_read |
-                                                    experimental::filesystem::perms::owner_write);
+    filesystem::permissions(fileName, filesystem::perms::owner_read |
+                                                    filesystem::perms::owner_write);
     rawWriteFile(fileName, contents);
 }
 


### PR DESCRIPTION
These changes were needed to build on macOS Catalina. For the largest part, it's just an upgrade to C++17 and the namespace changes that go with that, but also includes re-adding <sstream> to main.

There's an additional change to drop the filesystem library link instruction for APPLE platforms. This is a byproduct of the more recent compilers used in later macOS releases, but is probably better guarded on compiler versions than platform identifiers.