### PR TITLE
Make std::move qualified, which seems to be required by C++20

### DIFF
--- a/internal/http.cpp
+++ b/internal/http.cpp
@@ -100,7 +100,7 @@ struct NonceCollection
     void addNonce(string&& nonce)
     {
         unique_lock<mutex> lock(mutex_);
-        nonces_.push(move(nonce));
+        nonces_.push(std::move(nonce));
         timeout_ = ::time(nullptr);
     }
 };
@@ -150,7 +150,7 @@ size_t headerCallback(void * buffer, size_t size, size_t nmemb, void * h)
     string nonce = getHeaderValue("replay-nonce", reinterpret_cast<const char *>(buffer), byteCount);
     if (nonce.size())
     {
-        nonceCollection.addNonce(move(nonce));
+        nonceCollection.addNonce(std::move(nonce));
     }
 
     return byteCount;

--- a/lib/acme-lw.cpp
+++ b/lib/acme-lw.cpp
@@ -84,7 +84,7 @@ struct Ptr
             FREE(ptr_);
         }
 
-        ptr_ = move(ptr.ptr_);
+        ptr_ = std::move(ptr.ptr_);
         ptr.ptr_ = nullptr;
 
         return *this;


### PR DESCRIPTION
This fixes the compile errors. Or at least required by Zig's compiler - either way - seems worth upstreaming.