### PR TITLE
Add DNS challenge support for wildcard certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This project is yet another [_Let's Encrypt_](https://letsencrypt.org) client. It has the following properties.
 
 * The main artifact is a C++ static library.
-* Functionality only supports creating and updating certificates using http challenges.
+* Functionality supports creating and updating certificates using HTTP and DNS challenges.
 * All code runs 'in process', i.e., no processes are spawned.
+* Wildcard certificates are supported (via the DNS challenge).
 
 #### Building and Installing
 

--- a/internal/http.cpp
+++ b/internal/http.cpp
@@ -10,6 +10,10 @@
 #include <mutex>
 #include <stack>
 
+#ifdef _WIN32
+    #define strncasecmp(x,y,z) _strnicmp(x,y,z)
+#endif
+
 using namespace std;
 
 using namespace acme_lw;
@@ -216,6 +220,8 @@ void getNonce_()
 
     curl_easy_setopt(*curl, CURLOPT_HEADERFUNCTION, &headerCallback);
 
+    curl_easy_setopt(*curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);     // Use Schannel on Windows to validate SSL certificates for HTTPS requests
+
     // There will be no response (probably). We just pass this
     // for error handling
     vector<char> response;
@@ -259,6 +265,8 @@ Response doPost(const string& url, const string& postBody, const char * headerKe
     curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, dataCallback);
     curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &response.response_);
 
+    curl_easy_setopt(*curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+
     curl_slist h = { const_cast<char *>("Content-Type: application/jose+json"), nullptr };
     curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, &h);
 
@@ -290,6 +298,8 @@ vector<char> doGet(const string& url)
     curl_easy_setopt(*curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, dataCallback);
     curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &response);
+
+    curl_easy_setopt(*curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
 
     doCurl(curl, url, response);
 

--- a/lib/acme-lw.cpp
+++ b/lib/acme-lw.cpp
@@ -620,12 +620,6 @@ struct AcmeClientImpl
              */
             if (authz.at("status") != "valid")
             {
-                // If the user requests a wildcard certificate but wants to complete a HTTP challenge, then throw an error:
-                if (chg == AcmeClient::Challenge::HTTP && authz.contains("wildcard") && authz.at("wildcard") == true)
-                {
-                    throw AcmeException("Cannot obtain a wildcard certificate using a HTTP challenge -- use the DNS challenge to create wildcard certificates");
-                }
-
                 auto& challenges = authz.at("challenges");
                 for (const auto& challenge : challenges)
                 {

--- a/lib/acme-lw.cpp
+++ b/lib/acme-lw.cpp
@@ -605,7 +605,6 @@ struct AcmeClientImpl
         // Pass the challenges
         auto json = nlohmann::json::parse(response);
         auto& authorizations = json.at("authorizations");
-        bool challenge_found = false;
         for (const auto& authorization : authorizations)
         {
             auto authz = nlohmann::json::parse(doPostAsGet(authorization));
@@ -633,7 +632,6 @@ struct AcmeClientImpl
                         callback(domain, url, keyAuthorization);
 
                         verifyChallengePassed(challenge);
-                        challenge_found = true;
                         break;
                     }
                     else if (chg == AcmeClient::Challenge::DNS && challenge_type == "dns-01")
@@ -646,7 +644,6 @@ struct AcmeClientImpl
                         callback(domain, txtName, txtValue);
 
                         verifyChallengePassed(challenge);
-                        challenge_found = true;
                         break;
                     }
                 }

--- a/lib/acme-lw.h
+++ b/lib/acme-lw.h
@@ -80,6 +80,12 @@ public:
                                 const std::string& url,                         // [HTTP] URL of the GET request; [DNS] record name of the TXT record
                                 const std::string& keyAuthorization);           // [HTTP] Contents of the challenge file; [DNS] contents of the TXT record
 
+    // Contact the Let's Encrypt production or staging environments
+    enum class Environment { PRODUCTION, STAGING };
+
+    // Specify the challenge type (HTTP or DNS). Note that wildcard certificates can only be issued by DNS challenges.
+    enum class Challenge { HTTP, DNS };
+
     /**
         Issue a certificate for the domainNames.
         The first one will be the 'Subject' (CN) in the certificate.
@@ -87,12 +93,6 @@ public:
         throws std::exception, usually an instance of acme_lw::AcmeException
     */
     Certificate issueCertificate(const std::list<std::string>& domainNames, Callback, Challenge chg = Challenge::HTTP);
-
-    // Contact the Let's Encrypt production or staging environments
-    enum class Environment { PRODUCTION, STAGING };
-
-    // Specify the challenge type (HTTP or DNS). Note that wildcard certificates can only be issued by DNS challenges.
-    enum class Challenge { HTTP, DNS };
 
     /**
         Call once before instantiating AcmeClient.

--- a/lib/acme-lw.h
+++ b/lib/acme-lw.h
@@ -61,18 +61,24 @@ public:
         The implementation of this function allows Let's Encrypt to
         verify that the requestor has control of the domain name.
 
-        The callback may be called once for each domain name in the
+        [HTTP] The callback may be called once for each domain name in the
         'issueCertificate' call. The callback should do whatever is
         needed so that a GET on the 'url' returns the 'keyAuthorization',
         (which is what the Acme protocol calls the expected response.)
+
+        [DNS] The callback may be called once for each domain name in the
+        'issueCertificate' call. The callback should do whatever is
+        needed so that a DNS query of the TXT record name in 'url'
+        returns the value of 'keyAuthorization', (which is what the Acme
+        protocol calls the expected response.)
 
         Note that this function may not be called in cases where
         Let's Encrypt already believes the caller has control
         of the domain name.
     */
     typedef void (*Callback) (  const std::string& domainName,
-                                const std::string& url,
-                                const std::string& keyAuthorization);
+                                const std::string& url,                         // [HTTP] URL of the GET request; [DNS] record name of the TXT record
+                                const std::string& keyAuthorization);           // [HTTP] Contents of the challenge file; [DNS] contents of the TXT record
 
     /**
         Issue a certificate for the domainNames.
@@ -80,10 +86,14 @@ public:
 
         throws std::exception, usually an instance of acme_lw::AcmeException
     */
-    Certificate issueCertificate(const std::list<std::string>& domainNames, Callback);
+    Certificate issueCertificate(const std::list<std::string>& domainNames, Callback, Challenge chg = Challenge::HTTP);
 
     // Contact the Let's Encrypt production or staging environments
     enum class Environment { PRODUCTION, STAGING };
+
+    // Specify the challenge type (HTTP or DNS). Note that wildcard certificates can only be issued by DNS challenges.
+    enum class Challenge { HTTP, DNS };
+
     /**
         Call once before instantiating AcmeClient.
         

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -23,10 +23,21 @@ void   writeFile(const string& fileName, const string& contents);
 
 void handleChallenge(const string& domain, const string& url, const string& keyAuthorization)
 {
-    cout << "To verify ownership of " << domain << " make\n\n"
-            << "\t" << url << "\n\nrespond with this\n\n"
-            << "\t" << keyAuthorization << "\n\n"
-            << "Hit any key when done";
+    if (url.find("_acme-challenge.") == 0)
+    {
+        cout << "[DNS Challenge] To verify ownership of " << domain << " create a TXT record with name\n\n"
+                << "\t" << url << "\n\nand set it to the following value\n\n"
+                << "\t" << keyAuthorization << "\n\n"
+                << "Check for DNS propagation by running: nslookup -q=TXT " << url << "\n\n"
+                << "Hit any key when done";
+    }
+    else 
+    {
+        cout << "[HTTP Challenge] To verify ownership of " << domain << " make\n\n"
+                << "\t" << url << "\n\nrespond with this\n\n"
+                << "\t" << keyAuthorization << "\n\n"
+                << "Hit any key when done";
+    }
 
     getchar();
     cout << "\n***\n";

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -23,21 +23,10 @@ void   writeFile(const string& fileName, const string& contents);
 
 void handleChallenge(const string& domain, const string& url, const string& keyAuthorization)
 {
-    if (url.find("_acme-challenge.") == 0)
-    {
-        cout << "[DNS Challenge] To verify ownership of " << domain << " create a TXT record with name\n\n"
-                << "\t" << url << "\n\nand set it to the following value\n\n"
-                << "\t" << keyAuthorization << "\n\n"
-                << "Check for DNS propagation by running: nslookup -q=TXT " << url << "\n\n"
-                << "Hit any key when done";
-    }
-    else 
-    {
-        cout << "[HTTP Challenge] To verify ownership of " << domain << " make\n\n"
-                << "\t" << url << "\n\nrespond with this\n\n"
-                << "\t" << keyAuthorization << "\n\n"
-                << "Hit any key when done";
-    }
+    cout << "To verify ownership of " << domain << " make\n\n"
+            << "\t" << url << "\n\nrespond with this\n\n"
+            << "\t" << keyAuthorization << "\n\n"
+            << "Hit any key when done";
 
     getchar();
     cout << "\n***\n";


### PR DESCRIPTION
The following PR adds support for DNS-01 challenges and for building on Windows (MSVC 2022 with OpenSSL 3.4.1).

The changes were designed to maintain source-level compatibility with existing codebases that use this library for the HTTP-01 challenge. Only one optional parameter was added to the init() function to specify the desired challenge type. The callback function prototype remains the same.

Let me know if there are any regressions or changes requested. Thanks for making this excellent, extremely useful library!